### PR TITLE
move 'pgp' digest flag to 'Document.flags'

### DIFF
--- a/snoop/digest.py
+++ b/snoop/digest.py
@@ -63,7 +63,7 @@ def digest(doc):
     if emails.is_email(doc):
         data.update(emails.parse_email(doc))
 
-    if doc.flags.get('pgp'):
+    if 'pgp' in doc.flags:
         data['pgp'] = doc.flags['pgp']
 
     if doc.container_id:

--- a/snoop/digest.py
+++ b/snoop/digest.py
@@ -14,6 +14,10 @@ from . import pgp
 from .content_types import guess_content_type, guess_filetype
 from .utils import chunks
 
+INHERITABLE_DOCUMENT_FLAGS = [
+    'pgp',
+]
+
 def _path_bits(doc):
     if doc.container:
         yield from _path_bits(doc.container)
@@ -58,6 +62,8 @@ def digest(doc):
 
     if emails.is_email(doc):
         data.update(emails.parse_email(doc))
+        if doc.flags.get('pgp'):
+            data['pgp'] = doc.flags.get('pgp')
 
     if doc.container_id:
         data['message'] = doc.container_id
@@ -115,6 +121,12 @@ def create_children(doc, data, verbose=True):
                 'size': 0,
             })
 
+    inherited_flags = {
+        key: doc.flags[key]
+        for key in doc.flags
+        if key in INHERITABLE_DOCUMENT_FLAGS
+    }
+
     for info in children_info:
         child, created = models.Document.objects.update_or_create(
             container=doc,
@@ -123,6 +135,7 @@ def create_children(doc, data, verbose=True):
                 'disk_size': info['size'],
                 'content_type': info['content_type'],
                 'filename': info['filename'],
+                'flags': inherited_flags,
             },
         )
 

--- a/snoop/digest.py
+++ b/snoop/digest.py
@@ -62,8 +62,9 @@ def digest(doc):
 
     if emails.is_email(doc):
         data.update(emails.parse_email(doc))
-        if doc.flags.get('pgp'):
-            data['pgp'] = doc.flags.get('pgp')
+
+    if doc.flags.get('pgp'):
+        data['pgp'] = doc.flags['pgp']
 
     if doc.container_id:
         data['message'] = doc.container_id

--- a/snoop/emails.py
+++ b/snoop/emails.py
@@ -310,9 +310,10 @@ def open_email(doc):
     if email is None:
         raise RuntimeError
 
-    if email.pgp and not doc.flags.get('pgp'):
-        doc.flags['pgp'] = True
-        doc.save()
+    if email.pgp:
+        if 'pgp' not in doc.flags:
+            doc.flags['pgp'] = True
+            doc.save()
 
     return email
 

--- a/snoop/emails.py
+++ b/snoop/emails.py
@@ -292,20 +292,29 @@ def is_email(doc):
                                 'application/vnd.ms-outlook']
 
 def open_email(doc):
+    email = None
+
     if doc.content_type == 'message/x-emlx':
         with doc.open() as f:
             assert doc.container_id is None, "can't parse emlx in container"
-            return EmlxParser(f, doc.absolute_path)
+            email = EmlxParser(f, doc.absolute_path)
 
     if doc.content_type == 'message/rfc822':
         with doc.open() as f:
-            return EmailParser(f)
+            email = EmailParser(f)
 
     if doc.content_type == 'application/vnd.ms-outlook':
         with open_msg(doc) as f:
-            return EmailParser(f)
+            email = EmailParser(f)
 
-    raise RuntimeError
+    if email is None:
+        raise RuntimeError
+
+    if email.pgp and not doc.flags.get('pgp'):
+        doc.flags['pgp'] = True
+        doc.save()
+
+    return email
 
 def get_email_part(doc, part):
     return open_email(doc).open_part(part)
@@ -317,7 +326,6 @@ def raw_parse_email(doc):
         'tree': email.get_tree(),
         'attachments': email.get_attachments(),
         'text': email.get_text(),
-        'pgp': email.pgp,
     }
 
 def parse_email(doc):
@@ -327,6 +335,5 @@ def parse_email(doc):
         'text': parsed['text'],
         'tree': parsed['tree'],
         'attachments': parsed['attachments'],
-        'pgp': parsed.get('pgp', False),
     })
     return data


### PR DESCRIPTION
The 'pgp' flag is now propagated to the children via the
INHERITABLE_DOCUMENT_FLAGS global variable from 'digest.py'.
