### PR TITLE
change URL of document json

### DIFF
--- a/snoop/site/urls.py
+++ b/snoop/site/urls.py
@@ -5,7 +5,7 @@ from .. import views
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^doc/(?P<id>\d+)$', views.document),
-    url(r'^doc/(?P<id>\d+).json$', views.document_json),
+    url(r'^doc/(?P<id>\d+)/json$', views.document_json),
     url(r'^(?s)doc/(?P<id>\d+)/raw/.*$', views.document_raw),
     url(r'^doc/(?P<id>\d+)/ocr/(?P<tag>[^/]+)/.*$', views.document_ocr),
     url(r'^(?s)doc/(?P<id>\d+)/eml/.*$', views.document_as_eml),


### PR DESCRIPTION
this makes it easier for hoover-search to route requests:
- serve `doc.html` from hoover-ui if it looks like a preview URL
- proxy to hoover-snoop anything that contains a `/` after doc_id
