### PR TITLE
remove unused parts of django

### DIFF
--- a/snoop/site/settings/common.py
+++ b/snoop/site/settings/common.py
@@ -4,24 +4,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
     'snoop',
 ]
 
 MIDDLEWARE_CLASSES = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
 ROOT_URLCONF = 'snoop.site.urls'
@@ -41,25 +27,10 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'snoop.site.wsgi.application'
 
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
-]
-
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
-USE_I18N = True
-USE_L10N = True
+USE_I18N = False
+USE_L10N = False
 USE_TZ = True
 
 STATIC_URL = '/static/'

--- a/snoop/site/urls.py
+++ b/snoop/site/urls.py
@@ -3,7 +3,6 @@ from django.contrib import admin
 from .. import views
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
     url(r'^doc/(?P<id>\d+)$', views.document),
     url(r'^doc/(?P<id>\d+)/json$', views.document_json),
     url(r'^(?s)doc/(?P<id>\d+)/raw/.*$', views.document_raw),


### PR DESCRIPTION
I was hoping to remove the need to set `SECRET_KEY` but apparently Django won't start without one and it can be used outside of the users and sessions system. But this patch should make our server leaner and remove some of the useless database tables.
