### PR TITLE
update dependency versions

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,8 +2,8 @@ pip-tools
 psycopg2
 pathlib
 beautifulsoup4
-Django<1.10
-elasticsearch
+Django
+elasticsearch==2.4.0
 simplejson
 waitress
 lxml

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 beautifulsoup4==4.5.1
 chardet==2.3.0
 click==6.6                # via pip-tools
-Django==1.9.9
+Django==1.10.3
 elasticsearch==2.4.0
 exifread==2.1.2
 first==2.0.1              # via pip-tools
@@ -19,15 +19,15 @@ pip-tools==1.7.0
 psycopg2==2.6.2
 py==1.4.31                # via pytest
 pytest-django==3.0.0
-pytest==3.0.2
+pytest==3.0.3
 python-dateutil==2.5.3
 python-gnupg==0.3.9
 requests==2.11.1          # via tika
-simplejson==3.8.2
+simplejson==3.10.0
 six==1.10.0               # via pip-tools, python-dateutil
 tika==1.13.1
-urllib3==1.17             # via elasticsearch
-waitress==1.0.0
+urllib3==1.19             # via elasticsearch
+waitress==1.0.1
 
 # The following packages are commented out because they are
 # considered to be unsafe in a requirements file:


### PR DESCRIPTION
The tests pass.
Manual testing works as expected.
`elasticsearch` is locked at 2.4.0 because 5.0 introduces breaking changes.