### PR TITLE
Use magic to find types of documents without extensions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ available for each indexed document.
 ## Installation
 Snoop depends on _lxml_ (which compiles against _libxml2_ and _libxslt_) and
 _psycopg2_ (which compiles against the PostgreSQL client headers). On
-Debian/Ubuntu the required packages are `build-essential`, `python3-dev`,
+Debian/Ubuntu the required packages are `build-essential`, `libmagic`, `python3-dev`,
 `libxml2-dev`, `libxslt1-dev` and `postgresql-server-dev-9.4` (or newer).
 
 Snoop can talk to a bunch of tools. Some understand a certain data format,

--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ chardet
 python-gnupg
 lxml
 exifread
+python-magic

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,29 +4,32 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+appdirs==1.4.2            # via setuptools
 beautifulsoup4==4.5.1
 chardet==2.3.0
 click==6.6                # via pip-tools
-Django==1.10.4
+django==1.10.4
 elasticsearch==2.4.0
 exifread==2.1.2
 first==2.0.1              # via pip-tools
 lxml==3.7.1
+packaging==16.8           # via setuptools
 pathlib==1.0.1
 pip-tools==1.8.0
 psycopg2==2.6.2
 py==1.4.32                # via pytest
+pyparsing==2.1.10         # via packaging
 pytest-django==3.1.2
 pytest==3.0.5
 python-dateutil==2.6.0
 python-gnupg==0.3.9
+python-magic==0.4.12
 requests==2.12.4          # via tika
 simplejson==3.10.0
-six==1.10.0               # via pip-tools, python-dateutil
+six==1.10.0               # via packaging, pip-tools, python-dateutil, setuptools
 tika==1.13.1
 urllib3==1.19.1           # via elasticsearch
 waitress==1.0.1
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via tika

--- a/snoop/archives.py
+++ b/snoop/archives.py
@@ -6,7 +6,6 @@ from django.conf import settings
 import shutil
 from . import models
 from . import exceptions
-from .content_types import guess_filetype
 from .walker import Walker
 
 KNOWN_TYPES = {

--- a/snoop/content_types.py
+++ b/snoop/content_types.py
@@ -73,21 +73,20 @@ MAGIC_DESCRIPTION_TYPES = {
 
 MAGIC_READ_LIMIT = 24 * 1024 * 1024
 
+def libmagic_guess_content_type(file, filesize):
+    buffer = file.read(min(MAGIC_READ_LIMIT, filesize))
+    content_type = magic.from_buffer(buffer, mime=True)
+    if content_type in FILE_TYPES:
+        return content_type
+    magic_description = magic.from_buffer(buffer, mime=False)
+    return MAGIC_DESCRIPTION_TYPES.get(magic_description, content_type or '')
+
 def guess_filetype(doc):
     content_type = doc.content_type.split(';')[0]
-    magic_description = None
-    if not content_type:
-        with doc.open() as f:
-            buffer = f.read(min(doc.disk_size, MAGIC_READ_LIMIT))
-            content_type = magic.from_buffer(buffer, mime=True)
-            magic_description = magic.from_buffer(buffer, mime=False)
     if content_type in FILE_TYPES:
         return FILE_TYPES[content_type]
     else:
         supertype = content_type.split('/')[0]
         if supertype in ['audio', 'video', 'image']:
             return supertype
-        else:
-            if magic_description in MAGIC_DESCRIPTION_TYPES:
-                return FILE_TYPES.get(MAGIC_DESCRIPTION_TYPES[magic_description])
     return None

--- a/snoop/digest.py
+++ b/snoop/digest.py
@@ -12,7 +12,7 @@ from . import pst
 from . import exceptions
 from . import pgp
 from . import html
-from .content_types import guess_content_type, guess_filetype
+from .content_types import guess_filetype
 from .utils import chunks, word_count, worker_metrics, extract_exif
 
 INHERITABLE_DOCUMENT_FLAGS = [

--- a/snoop/digest.py
+++ b/snoop/digest.py
@@ -12,7 +12,7 @@ from . import pst
 from . import exceptions
 from . import pgp
 from . import html
-from .content_types import guess_filetype
+from .content_types import guess_filetype, libmagic_guess_content_type
 from .utils import chunks, word_count, worker_metrics, extract_exif
 
 INHERITABLE_DOCUMENT_FLAGS = [
@@ -46,6 +46,9 @@ def digest(doc):
     if not doc.sha1:
         with doc.open() as f:
             md5, sha1, fsize = _calculate_hashes(f)
+            if not doc.content_type:
+                f.seek(0)
+                doc.content_type = libmagic_guess_content_type(f, fsize)
         if not doc.disk_size:
             doc.disk_size = fsize
         doc.sha1 = sha1

--- a/testsuite/test_digest.py
+++ b/testsuite/test_digest.py
@@ -54,3 +54,23 @@ def test_digest_image_exif(document_collection):
 
     assert data['location'] == '33.87546081542969, -116.3016196017795'
     assert data['date-created'] == '2006-02-11T11:06:37'
+
+def test_digest_magic_file_types(document_collection):
+    expected_types = {
+        "no-extension/file_pst": "email-archive",
+        "no-extension/file_7z": "archive",
+        "no-extension/file_zip": "archive",
+        "no-extension/file_eml": "text",
+        "no-extension/file_html": "html",
+        "no-extension/file_jpg": "image",
+        "no-extension/file_json": "text",
+        "no-extension/file_text": "text",
+        "no-extension/file_pdf": "pdf",
+        "no-extension/file_docx": "doc",
+        "no-extension/file_doc": "doc",
+        "no-extension/file_odt": "doc",
+        "no-extension/file_msg": "email",
+    }
+    for path in expected_types:
+        data = digest_path(path, document_collection)
+        assert data['type'] == expected_types[path]

--- a/testsuite/test_digest.py
+++ b/testsuite/test_digest.py
@@ -1,6 +1,7 @@
 import pytest
 from snoop import digest, models
 from snoop.content_types import guess_content_type
+from snoop import pst, archives
 
 PATH_TEXT = "disk-files/pdf-doc-txt/easychair.txt"
 PATH_HTML = "disk-files/bad-html/alert.html"
@@ -11,6 +12,8 @@ def no_ocr_models(monkeypatch):
     func_empty_list = lambda *a, **k: []
     monkeypatch.setattr(models.Ocr.objects, "filter", func_empty_list)
     monkeypatch.setattr(models.Ocr.objects, "all", func_empty_list)
+    monkeypatch.setattr(pst, "extract_to_base", func_empty_list)
+    monkeypatch.setattr(archives, "extract_to_base", func_empty_list)
 
 def digest_path(path, collection):
     content_type = guess_content_type(path)


### PR DESCRIPTION
libmagic, that is.

Might be worth doing: use regexes on `MAGIC_DESCRIPTION_TYPES` in case the found descriptions will change (because more metadata is found).