### PR TITLE
make walk create digest jobs

### DIFF
--- a/snoop/walker.py
+++ b/snoop/walker.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from . import models
+from . import queues
 from .content_types import guess_content_type
 
 FOLDER = 'application/x-directory'
@@ -57,6 +58,7 @@ class Walker(object):
                 collection=self.collection,
             )
             self.documents.append((new_doc, created))
+            queues.put('digest', {'id': new_doc.id})
         for child in folder.iterdir():
             self.handle(child, new_doc)
 
@@ -74,6 +76,7 @@ class Walker(object):
             },
         )
         self.documents.append((new_doc, created))
+        queues.put('digest', {'id': new_doc.id})
 
 def files_in(doc):
     child_documents = models.Document.objects.filter(parent=doc)

--- a/snoop/walker.py
+++ b/snoop/walker.py
@@ -30,13 +30,16 @@ class Walker(object):
         return file.relative_to(self.root)
 
     def handle(self, item, parent):
+        print("WALK ENTER   ", str(self._path(item)))
         if item.is_dir():
             self.handle_folder(item, parent)
         else:
             self.handle_file(item, parent)
+        print("WALK EXIT    ", str(self._path(item)))
 
     def handle_folder(self, folder, parent):
         path = self._path(folder)
+        print("HANDLE FOLDER", str(path))
         if str(path) == '.':
             if self.container_doc:
                 new_doc = self.container_doc
@@ -71,6 +74,7 @@ class Walker(object):
 
     def handle_file(self, file, parent):
         path = self._path(file)
+        print("HANDLE FILE  ", str(path))
         new_doc, created = models.Document.objects.get_or_create(
             path=path,
             parent=parent,

--- a/snoop/walker.py
+++ b/snoop/walker.py
@@ -64,10 +64,12 @@ class Walker(object):
             )
             self.documents.append((new_doc, created))
 
+        folder_mtime = os.path.getmtime(str(folder.resolve()))
         if created or \
                 not new_doc.digested_at or \
-                new_doc.digested_at.timestamp() < os.path.getmtime(str(folder.resolve())):
-            queues.put('digest', {'id': new_doc.id})
+                new_doc.digested_at.timestamp() <= folder_mtime:
+            if new_doc.path:  # avoid digesting / indexing the root
+                queues.put('digest', {'id': new_doc.id})
 
         for child in folder.iterdir():
             self.handle(child, new_doc)
@@ -87,9 +89,10 @@ class Walker(object):
             },
         )
         self.documents.append((new_doc, created))
+        file_mtime = os.path.getmtime(str(file.resolve()))
         if created or \
                 not new_doc.digested_at or \
-                new_doc.digested_at.timestamp() < os.path.getmtime(str(file.resolve())):
+                new_doc.digested_at.timestamp() <= file_mtime:
             queues.put('digest', {'id': new_doc.id})
 
 def files_in(doc):

--- a/snoop/walker.py
+++ b/snoop/walker.py
@@ -60,10 +60,12 @@ class Walker(object):
                 collection=self.collection,
             )
             self.documents.append((new_doc, created))
-            if created or \
-                    not new_doc.digested_at or \
-                    new_doc.digested_at.timestamp() < os.path.getmtime(folder.resolve()):
-                queues.put('digest', {'id': new_doc.id})
+
+        if created or \
+                not new_doc.digested_at or \
+                new_doc.digested_at.timestamp() < os.path.getmtime(str(folder.resolve())):
+            queues.put('digest', {'id': new_doc.id})
+
         for child in folder.iterdir():
             self.handle(child, new_doc)
 
@@ -83,7 +85,7 @@ class Walker(object):
         self.documents.append((new_doc, created))
         if created or \
                 not new_doc.digested_at or \
-                new_doc.digested_at.timestamp() < os.path.getmtime(file.resolve()):
+                new_doc.digested_at.timestamp() < os.path.getmtime(str(file.resolve())):
             queues.put('digest', {'id': new_doc.id})
 
 def files_in(doc):

--- a/snoop/walker.py
+++ b/snoop/walker.py
@@ -39,8 +39,9 @@ class Walker(object):
         if str(path) == '.':
             if self.container_doc:
                 new_doc = self.container_doc
+                created = True
             else:
-                new_doc, _ = models.Document.objects.get_or_create(
+                new_doc, created = models.Document.objects.get_or_create(
                     path='',
                     disk_size=0,
                     content_type=FOLDER,
@@ -58,7 +59,10 @@ class Walker(object):
                 collection=self.collection,
             )
             self.documents.append((new_doc, created))
-            queues.put('digest', {'id': new_doc.id})
+            if created or \
+                    not new_doc.digested_at or \
+                    new_doc.digested_at.timestamp() < os.path.getmtime((folder.resolve()):
+                queues.put('digest', {'id': new_doc.id})
         for child in folder.iterdir():
             self.handle(child, new_doc)
 
@@ -76,7 +80,10 @@ class Walker(object):
             },
         )
         self.documents.append((new_doc, created))
-        queues.put('digest', {'id': new_doc.id})
+        if created or \
+                not new_doc.digested_at or \
+                new_doc.digested_at.timestamp() < os.path.getmtime((file.resolve()):
+            queues.put('digest', {'id': new_doc.id})
 
 def files_in(doc):
     child_documents = models.Document.objects.filter(parent=doc)

--- a/snoop/walker.py
+++ b/snoop/walker.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from . import models
 from . import queues
@@ -61,7 +62,7 @@ class Walker(object):
             self.documents.append((new_doc, created))
             if created or \
                     not new_doc.digested_at or \
-                    new_doc.digested_at.timestamp() < os.path.getmtime((folder.resolve()):
+                    new_doc.digested_at.timestamp() < os.path.getmtime(folder.resolve()):
                 queues.put('digest', {'id': new_doc.id})
         for child in folder.iterdir():
             self.handle(child, new_doc)
@@ -82,7 +83,7 @@ class Walker(object):
         self.documents.append((new_doc, created))
         if created or \
                 not new_doc.digested_at or \
-                new_doc.digested_at.timestamp() < os.path.getmtime((file.resolve()):
+                new_doc.digested_at.timestamp() < os.path.getmtime(file.resolve()):
             queues.put('digest', {'id': new_doc.id})
 
 def files_in(doc):


### PR DESCRIPTION
This means we can rerun `./manage.py walk` to find new files.

Right now, modified files are re-digested, but deleted or moved files are not updated.